### PR TITLE
Update stress_random.js

### DIFF
--- a/test1/stress_random.js
+++ b/test1/stress_random.js
@@ -28,9 +28,9 @@ export default function () {
         },
         {
             jsonrpc: "2.0",
-            method: "eth_getTransactionReceipt",
+            method: "eth_getTransactionByHash",
             params: [
-                "0xabfe871f8bdb0f526611e8620a4569cdd7617f7e2bbc377fe6ab5b2a27e76d6e",
+                "0xa3f6c173b0085c670683ab9fe3272aae1bf712c17d89fd0dbe784441b83c967f",
             ],
             id: 1,
         },


### PR DESCRIPTION
As per task https://docs.google.com/spreadsheets/d/1rTmn-Niq-zAZnm6b1qaFS6I81No_NHBczYDWovn1zmQ/edit#gid=0, Methods: eth_getTransactionBy*******, eth_blockNumber, eth_getTransactionByBlockNumberAndIndex

Should be eth_getTransactionBy* rather than eth_getTransactionReceipt